### PR TITLE
WIP: Small tweaks...

### DIFF
--- a/src/directory.rs
+++ b/src/directory.rs
@@ -8,6 +8,7 @@ use utils::{
 };
 
 use Database;
+use Filenames;
 
 use ffi;
 
@@ -16,6 +17,14 @@ pub struct Directory<'d>(
     *mut ffi::notmuch_directory_t,
     marker::PhantomData<&'d mut Database>,
 );
+
+impl<'d> Directory<'d>{
+    pub fn child_directories(self: &Self) -> Filenames<'d>{
+        Filenames::new(unsafe {
+            ffi::notmuch_directory_get_child_directories(self.0)
+        })
+    }
+}
 
 impl<'d> NewFromPtr<*mut ffi::notmuch_directory_t> for Directory<'d> {
     fn new(ptr: *mut ffi::notmuch_directory_t) -> Directory<'d> {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -102,7 +102,7 @@ notmuch_enum! {
         NOTMUCH_SORT_OLDEST_FIRST => OldestFirst,
         NOTMUCH_SORT_NEWEST_FIRST => NewestFirst,
         NOTMUCH_SORT_MESSAGE_ID => MessageID,
-        NOTMUCH_SORT_UNSORTED => ReadWrite
+        NOTMUCH_SORT_UNSORTED => Unsorted
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -52,7 +52,7 @@ impl<'q, 'd> Message<'q, 'd>{
             ffi::notmuch_message_get_replies(self.0)
         })
     }
-
+#[cfg(feature = "0.26")]
     pub fn count_files(self: &Self) -> i32
     {
         unsafe {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -46,7 +46,7 @@ impl<'q, 'd> Thread<'q, 'd>{
             ffi::notmuch_thread_get_total_messages(self.0)
         }
     }
-
+#[cfg(feature = "0.26")]
     pub fn total_files(self: &Self) -> i32{
         unsafe {
             ffi::notmuch_thread_get_total_files(self.0)


### PR DESCRIPTION
I realize these should really go into separate PRs, but I wanted to get some feedback first. 3 changes here:

- restrict 0.26 functionality (`files`) behind a feature `0.26`, so that 0.25 users (Fedora) can still use this crate
- add `Directory::child_directories` - straightforward
- fix what seems to be a typo: *no sorting* enum value was called `ReadWrite`, changed to `Unsorted`. This should probably contain a version bump.