### PR TITLE
Add Message::header

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@ pub type Result<T> = result::Result<T, Error>;
 pub enum Error {
     IoError(io::Error),
     NotmuchError(ffi::Status),
+    UnspecifiedError,
 }
 
 impl fmt::Display for Error {
@@ -27,6 +28,7 @@ impl std::error::Error for Error {
         match *self {
             Error::IoError(ref e) => error::Error::description(e),
             Error::NotmuchError(ref e) => e.description(),
+            Error::UnspecifiedError => "Generic notmuch error",
         }
     }
 
@@ -34,6 +36,7 @@ impl std::error::Error for Error {
         match *self {
             Error::IoError(ref e) => Some(e),
             Error::NotmuchError(ref e) => Some(e),
+            Error::UnspecifiedError => None
         }
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,9 @@
 use std::ops::Drop;
 use std::rc::Rc;
 use std::path::PathBuf;
+use std::ffi::CString;
+
+use error::{Error, Result};
 
 use ffi;
 use utils::{
@@ -73,6 +76,18 @@ impl Message{
         PathBuf::from(unsafe {
             ffi::notmuch_message_get_filename(self.0.ptr)
         }.to_str().unwrap())
+    }
+
+    pub fn header(&self, name: &str) -> Result<&str> {
+        let ret = unsafe {
+            ffi::notmuch_message_get_header(self.0.ptr,
+                CString::new(name).unwrap().as_ptr())
+        };
+        if ret.is_null() {
+            Err(Error::UnspecifiedError)
+        } else {
+            Ok(ret.to_str().unwrap())
+        }
     }
 }
 


### PR DESCRIPTION
Adds the ability to get a header from a function. Add unspecified error value, because notmuch doesn't offer a detailed one :(