### PR TITLE
Make Message::header return an Option in its Result

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -89,12 +89,10 @@ impl<'o, Owner: MessageOwner + 'o> Message<'o, Owner> {
         if ret.is_null() {
             Err(Error::UnspecifiedError)
         } else {
-            let ret = ret.to_str().unwrap();
-            if ret == "" {
-                Ok(None)
-            } else {
-                Ok(Some(ret))
-            }
+            Ok(match ret.to_str().unwrap() {
+                "" => None,
+                ret => Some(ret)
+            })
         }
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -83,13 +83,18 @@ impl<'o, Owner: MessageOwner + 'o> Message<'o, Owner> {
         unsafe { ffi::notmuch_message_get_date(self.handle.ptr) }
     }
 
-    pub fn header(&self, name: &str) -> Result<&str> {
+    pub fn header(&self, name: &str) -> Result<Option<&str>> {
         let name = CString::new(name).unwrap();
         let ret = unsafe { ffi::notmuch_message_get_header(self.handle.ptr, name.as_ptr()) };
         if ret.is_null() {
             Err(Error::UnspecifiedError)
         } else {
-            Ok(ret.to_str().unwrap())
+            let ret = ret.to_str().unwrap();
+            if ret == "" {
+                Ok(None)
+            } else {
+                Ok(Some(ret))
+            }
         }
     }
 


### PR DESCRIPTION
Since `notmuch_message_get_header` responds with `""` if no header with the supplied key was found, a higher level API equivalent in Rust would be to return an Option rather than just the empty `&str`.

Example using the returned value with a `match`:

```rust
match msg.header("x-gobbledigook") {
    Ok(Some(_) => println!("Found"),
    Ok(None) => println!("Not found"),
    Err(err) => println!("Error: {:?}", err)
}
```