### PR TITLE
Switch to more legible `where` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ fn main() {
     let mut mail_path = std::env::home_dir().unwrap();
     mail_path.push(".mail");
 
-    let db = notmuch::Database::open(&mail_path.to_str().unwrap().to_string(), notmuch::DatabaseMode::ReadOnly).unwrap();
-    let query = db.create_query(&"".to_string()).unwrap();
+    let db = notmuch::Database::open(&mail_path, notmuch::DatabaseMode::ReadOnly).unwrap();
+    let query = db.create_query("").unwrap();
     let mut threads = query.search_threads().unwrap();
 
     while let Some(thread) = threads.next() {

--- a/src/database.rs
+++ b/src/database.rs
@@ -57,7 +57,10 @@ pub struct Database {
 impl TagsOwner for Database {}
 
 impl Database {
-    pub fn create<P: AsRef<Path>>(path: &P) -> Result<Self> {
+    pub fn create<P>(path: &P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
         let path_str = CString::new(path.as_ref().to_str().unwrap()).unwrap();
 
         let mut db = ptr::null_mut();
@@ -68,7 +71,10 @@ impl Database {
         })
     }
 
-    pub fn open<P: AsRef<Path>>(path: &P, mode: DatabaseMode) -> Result<Self> {
+    pub fn open<P>(path: &P, mode: DatabaseMode) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
         let path_str = CString::new(path.as_ref().to_str().unwrap()).unwrap();
 
         let mut db = ptr::null_mut();
@@ -88,27 +94,28 @@ impl Database {
         Ok(())
     }
 
-    pub fn compact<P: AsRef<Path>, F: FnMut(&str)>(
-        path: &P,
-        backup_path: Option<&P>,
-    ) -> Result<()> {
+    pub fn compact<P, F>(path: &P, backup_path: Option<&P>) -> Result<()>
+    where
+        P: AsRef<Path>,
+        F: FnMut(&str),
+    {
         let status: Option<F> = None;
         Database::_compact(path, backup_path, status)
     }
 
-    pub fn compact_with_status<P: AsRef<Path>, F: FnMut(&str)>(
-        path: &P,
-        backup_path: Option<&P>,
-        status: F,
-    ) -> Result<()> {
+    pub fn compact_with_status<P, F>(path: &P, backup_path: Option<&P>, status: F) -> Result<()>
+    where
+        P: AsRef<Path>,
+        F: FnMut(&str),
+    {
         Database::_compact(path, backup_path, Some(status))
     }
 
-    fn _compact<P: AsRef<Path>, F: FnMut(&str)>(
-        path: &P,
-        backup_path: Option<&P>,
-        status: Option<F>,
-    ) -> Result<()> {
+    fn _compact<P, F>(path: &P, backup_path: Option<&P>, status: Option<F>) -> Result<()>
+    where
+        P: AsRef<Path>,
+        F: FnMut(&str),
+    {
         extern "C" fn wrapper<F: FnMut(&str)>(
             message: *const libc::c_char,
             closure: *mut libc::c_void,
@@ -174,18 +181,30 @@ impl Database {
         unsafe { ffi::notmuch_database_needs_upgrade(self.handle.ptr) == 1 }
     }
 
-    pub fn upgrade<F: FnMut(f64)>(&mut self) -> Result<()> {
+    pub fn upgrade<F>(&mut self) -> Result<()>
+    where
+        F: FnMut(f64),
+    {
         let status: Option<F> = None;
         self._upgrade(status)
     }
 
-    pub fn upgrade_with_status<F: FnMut(f64)>(&mut self, status: F) -> Result<()> {
+    pub fn upgrade_with_status<F>(&mut self, status: F) -> Result<()>
+    where
+        F: FnMut(f64),
+    {
         self._upgrade(Some(status))
     }
 
-    fn _upgrade<F: FnMut(f64)>(&mut self, status: Option<F>) -> Result<()> {
+    fn _upgrade<F>(&mut self, status: Option<F>) -> Result<()>
+    where
+        F: FnMut(f64),
+    {
         #[allow(trivial_numeric_casts)]
-        extern "C" fn wrapper<F: FnMut(f64)>(closure: *mut libc::c_void, progress: libc::c_double) {
+        extern "C" fn wrapper<F>(closure: *mut libc::c_void, progress: libc::c_double)
+        where
+            F: FnMut(f64),
+        {
             let closure = closure as *mut F;
             unsafe { (*closure)(progress as f64) }
         }
@@ -208,7 +227,10 @@ impl Database {
         Ok(())
     }
 
-    pub fn directory<'d, P: AsRef<Path>>(&'d self, path: &P) -> Result<Option<Directory<'d>>> {
+    pub fn directory<'d, P>(&'d self, path: &P) -> Result<Option<Directory<'d>>>
+    where
+        P: AsRef<Path>,
+    {
         <Self as DatabaseExt>::directory(self, path)
     }
 
@@ -222,10 +244,10 @@ impl Database {
 }
 
 pub trait DatabaseExt {
-    fn create_query<'d, D: Into<Supercow<'d, Database>>>(
-        database: D,
-        query_string: &str,
-    ) -> Result<Query<'d>> {
+    fn create_query<'d, D>(database: D, query_string: &str) -> Result<Query<'d>>
+    where
+        D: Into<Supercow<'d, Database>>,
+    {
         let dbref = database.into();
         let query_str = CString::new(query_string).unwrap();
 
@@ -234,7 +256,10 @@ pub trait DatabaseExt {
         Ok(Query::from_ptr(query, Supercow::phantom(dbref)))
     }
 
-    fn all_tags<'d, D: Into<Supercow<'d, Database>>>(database: D) -> Result<Tags<'d, Database>> {
+    fn all_tags<'d, D>(database: D) -> Result<Tags<'d, Database>>
+    where
+        D: Into<Supercow<'d, Database>>,
+    {
         let dbref = database.into();
 
         let tags = unsafe { ffi::notmuch_database_get_all_tags(dbref.handle.ptr) };
@@ -242,10 +267,11 @@ pub trait DatabaseExt {
         Ok(Tags::from_ptr(tags, Supercow::phantom(dbref)))
     }
 
-    fn directory<'d, D: Into<Supercow<'d, Database>>, P: AsRef<Path>>(
-        database: D,
-        path: &P,
-    ) -> Result<Option<Directory<'d>>> {
+    fn directory<'d, D, P>(database: D, path: &P) -> Result<Option<Directory<'d>>>
+    where
+        D: Into<Supercow<'d, Database>>,
+        P: AsRef<Path>,
+    {
         let dbref = database.into();
 
         let path_str = CString::new(path.as_ref().to_str().unwrap()).unwrap();

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -26,10 +26,10 @@ pub struct Directory<'d> {
 impl<'d> FilenamesOwner for Directory<'d> {}
 
 impl<'d> Directory<'d> {
-    pub fn from_ptr<O: Into<Phantomcow<'d, Database>>>(
-        ptr: *mut ffi::notmuch_directory_t,
-        owner: O,
-    ) -> Directory<'d> {
+    pub fn from_ptr<O>(ptr: *mut ffi::notmuch_directory_t, owner: O) -> Directory<'d>
+    where
+        O: Into<Phantomcow<'d, Database>>,
+    {
         Directory {
             handle: DirectoryPtr { ptr },
             marker: owner.into(),
@@ -42,9 +42,10 @@ impl<'d> Directory<'d> {
 }
 
 pub trait DirectoryExt<'d> {
-    fn child_directories<'s, S: Into<Supercow<'s, Directory<'d>>>>(
-        directory: S,
-    ) -> Filenames<'s, Directory<'d>> {
+    fn child_directories<'s, S>(directory: S) -> Filenames<'s, Directory<'d>>
+    where
+        S: Into<Supercow<'s, Directory<'d>>>,
+    {
         let dir = directory.into();
         Filenames::from_ptr(
             unsafe { ffi::notmuch_directory_get_child_directories(dir.handle.ptr) },

--- a/src/filenames.rs
+++ b/src/filenames.rs
@@ -25,16 +25,22 @@ impl Drop for FilenamesPtr {
 }
 
 #[derive(Debug)]
-pub struct Filenames<'o, Owner: FilenamesOwner + 'o> {
+pub struct Filenames<'o, O>
+where
+    O: FilenamesOwner + 'o,
+{
     pub(crate) handle: FilenamesPtr,
-    pub(crate) marker: Phantomcow<'o, Owner>,
+    pub(crate) marker: Phantomcow<'o, O>,
 }
 
-impl<'o, Owner: FilenamesOwner + 'o> Filenames<'o, Owner> {
-    pub fn from_ptr<O: Into<Phantomcow<'o, Owner>>>(
-        ptr: *mut ffi::notmuch_filenames_t,
-        owner: O,
-    ) -> Filenames<'o, Owner> {
+impl<'o, O> Filenames<'o, O>
+where
+    O: FilenamesOwner + 'o,
+{
+    pub fn from_ptr<P>(ptr: *mut ffi::notmuch_filenames_t, owner: P) -> Filenames<'o, O>
+    where
+        P: Into<Phantomcow<'o, O>>,
+    {
         Filenames {
             handle: FilenamesPtr { ptr },
             marker: owner.into(),
@@ -42,7 +48,10 @@ impl<'o, Owner: FilenamesOwner + 'o> Filenames<'o, Owner> {
     }
 }
 
-impl<'o, Owner: FilenamesOwner + 'o> Iterator for Filenames<'o, Owner> {
+impl<'o, O> Iterator for Filenames<'o, O>
+where
+    O: FilenamesOwner + 'o,
+{
     type Item = PathBuf;
 
     fn next(self: &mut Self) -> Option<Self::Item> {
@@ -62,5 +71,5 @@ impl<'o, Owner: FilenamesOwner + 'o> Iterator for Filenames<'o, Owner> {
     }
 }
 
-unsafe impl<'o, Owner: FilenamesOwner + 'o> Send for Filenames<'o, Owner> {}
-unsafe impl<'o, Owner: FilenamesOwner + 'o> Sync for Filenames<'o, Owner> {}
+unsafe impl<'o, O> Send for Filenames<'o, O> where O: FilenamesOwner + 'o {}
+unsafe impl<'o, O> Sync for Filenames<'o, O> where O: FilenamesOwner + 'o {}

--- a/src/query.rs
+++ b/src/query.rs
@@ -33,27 +33,30 @@ impl<'d> ThreadsOwner for Query<'d> {}
 impl<'d> MessagesOwner for Query<'d> {}
 
 impl<'d> Query<'d> {
-    pub(crate) fn from_ptr<O: Into<Phantomcow<'d, Database>>>(
-        ptr: *mut ffi::notmuch_query_t,
-        owner: O,
-    ) -> Query<'d> {
+    pub(crate) fn from_ptr<O>(ptr: *mut ffi::notmuch_query_t, owner: O) -> Query<'d>
+    where
+        O: Into<Phantomcow<'d, Database>>,
+    {
         Query {
             handle: QueryPtr { ptr },
             marker: owner.into(),
         }
     }
 
-    pub(crate) fn from_handle<O: Into<Phantomcow<'d, Database>>>(
-        handle: QueryPtr,
-        owner: O,
-    ) -> Query<'d> {
+    pub(crate) fn from_handle<O>(handle: QueryPtr, owner: O) -> Query<'d>
+    where
+        O: Into<Phantomcow<'d, Database>>,
+    {
         Query {
             handle,
             marker: owner.into(),
         }
     }
 
-    pub fn create<D: Into<Supercow<'d, Database>>>(db: D, query_string: &str) -> Result<Self> {
+    pub fn create<D>(db: D, query_string: &str) -> Result<Self>
+    where
+        D: Into<Supercow<'d, Database>>,
+    {
         let dbref = db.into();
         dbref
             .handle
@@ -97,9 +100,10 @@ impl<'d> Query<'d> {
 }
 
 pub trait QueryExt<'d> {
-    fn search_threads<'q, Q: Into<Supercow<'q, Query<'d>>>>(
-        query: Q,
-    ) -> Result<Threads<'q, Query<'d>>> {
+    fn search_threads<'q, Q>(query: Q) -> Result<Threads<'q, Query<'d>>>
+    where
+        Q: Into<Supercow<'q, Query<'d>>>,
+    {
         let queryref = query.into();
 
         let mut thrds = ptr::null_mut();
@@ -111,9 +115,10 @@ pub trait QueryExt<'d> {
         Ok(Threads::from_ptr(thrds, Supercow::phantom(queryref)))
     }
 
-    fn search_messages<'q, Q: Into<Supercow<'q, Query<'d>>>>(
-        query: Q,
-    ) -> Result<Messages<'q, Query<'d>>> {
+    fn search_messages<'q, Q>(query: Q) -> Result<Messages<'q, Query<'d>>>
+    where
+        Q: Into<Supercow<'q, Query<'d>>>,
+    {
         let queryref = query.into();
 
         let mut msgs = ptr::null_mut();

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -25,11 +25,14 @@ pub struct Tags<'o, Owner: TagsOwner + 'o> {
     marker: Phantomcow<'o, Owner>,
 }
 
-impl<'o, Owner: TagsOwner + 'o> Tags<'o, Owner> {
-    pub fn from_ptr<O: Into<Phantomcow<'o, Owner>>>(
-        ptr: *mut ffi::notmuch_tags_t,
-        owner: O,
-    ) -> Tags<'o, Owner> {
+impl<'o, O> Tags<'o, O>
+where
+    O: TagsOwner + 'o,
+{
+    pub fn from_ptr<P>(ptr: *mut ffi::notmuch_tags_t, owner: P) -> Tags<'o, O>
+    where
+        P: Into<Phantomcow<'o, O>>,
+    {
         Tags {
             handle: TagsPtr { ptr },
             marker: owner.into(),
@@ -37,7 +40,10 @@ impl<'o, Owner: TagsOwner + 'o> Tags<'o, Owner> {
     }
 }
 
-impl<'o, Owner: TagsOwner + 'o> Iterator for Tags<'o, Owner> {
+impl<'o, O> Iterator for Tags<'o, O>
+where
+    O: TagsOwner + 'o,
+{
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -58,9 +64,13 @@ impl<'o, Owner: TagsOwner + 'o> Iterator for Tags<'o, Owner> {
     }
 }
 
-pub trait TagsExt<'o, Owner: TagsOwner + 'o> {}
+pub trait TagsExt<'o, O>
+where
+    O: TagsOwner + 'o,
+{
+}
 
-impl<'o, Owner: TagsOwner + 'o> TagsExt<'o, Owner> for Tags<'o, Owner> {}
+impl<'o, O> TagsExt<'o, O> for Tags<'o, O> where O: TagsOwner + 'o {}
 
-unsafe impl<'o, Owner: TagsOwner + 'o> Send for Tags<'o, Owner> {}
-unsafe impl<'o, Owner: TagsOwner + 'o> Sync for Tags<'o, Owner> {}
+unsafe impl<'o, O> Send for Tags<'o, O> where O: TagsOwner + 'o {}
+unsafe impl<'o, O> Sync for Tags<'o, O> where O: TagsOwner + 'o {}


### PR DESCRIPTION
Hi Dirk, when you fixed up lifetimes, some of the API changed and I was confused by the syntax at first. I guess I was more used to `where` clauses, [which seem to be newer](https://stackoverflow.com/questions/28405621/what-is-the-syntax-and-semantics-of-the-where-keyword). So I thought I'd take the liberty to update it.

All the changes are in line with what rustfmt suggests, the only bit I did not change was leaving the `.as_result()`s in `database.rs` on their own line.

I should've checked if there's other changes on my master, I simplified and subsequently tested the example in the `README.md`.