### PR TITLE
Make sure to cast time_t to i64 so that notmuch-rs works on 32 bit platforms too

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -86,7 +86,7 @@ where
     }
 
     pub fn date(&self) -> i64 {
-        unsafe { ffi::notmuch_message_get_date(self.handle.ptr) }
+        unsafe { ffi::notmuch_message_get_date(self.handle.ptr) as i64 }
     }
 
     pub fn header(&self, name: &str) -> Result<Option<&str>> {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -94,12 +94,12 @@ where
 
     /// Get the date of the oldest message in 'thread' as a time_t value.
     pub fn oldest_date(self: &Self) -> i64 {
-        unsafe { ffi::notmuch_thread_get_oldest_date(self.handle.ptr) }
+        unsafe { ffi::notmuch_thread_get_oldest_date(self.handle.ptr) as i64 }
     }
 
     /// Get the date of the newest message in 'thread' as a time_t value.
     pub fn newest_date(self: &Self) -> i64 {
-        unsafe { ffi::notmuch_thread_get_newest_date(self.handle.ptr) }
+        unsafe { ffi::notmuch_thread_get_newest_date(self.handle.ptr) as i64 }
     }
 }
 


### PR DESCRIPTION
While playing with CI and i686 builds I noticed that notmuch-rs failing to build. There might be 32bit notmuch users out there though, who knows!