### PR TITLE
Return Result<(), Status::NotmuchError> instead of Status

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -4,6 +4,7 @@
 
 use libc::{c_char, c_double, c_int, c_uint, c_ulong, c_void, time_t};
 
+use error::{Error, Result};
 use std::{error, fmt, str};
 
 use utils::ToStr;
@@ -43,17 +44,17 @@ impl notmuch_status_t {
         !self.is_ok()
     }
 
-    pub fn as_result(self) -> Result<(), Self> {
+    pub fn as_result(self) -> Result<()> {
         if self.is_ok() {
             Ok(())
         } else {
-            Err(self)
+            Err(Error::NotmuchError(Status::from(self)))
         }
     }
 }
 
 impl ToStr for Status {
-    fn to_str<'a>(&self) -> Result<&'a str, str::Utf8Error> {
+    fn to_str<'a>(&self) -> std::result::Result<&'a str, str::Utf8Error> {
         unsafe { notmuch_status_to_string((*self).into()) }.to_str()
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -5,7 +5,6 @@ use supercow::{Phantomcow, Supercow};
 
 use error::{Error, Result};
 use ffi;
-use ffi::Status;
 use utils::ToStr;
 use Filenames;
 use FilenamesOwner;
@@ -106,18 +105,18 @@ where
         <Self as MessageExt<'o, O>>::tags(self)
     }
 
-    pub fn add_tag(self: &Self, tag: &str) -> Status {
+    pub fn add_tag(self: &Self, tag: &str) -> Result<()> {
         let tag = CString::new(tag).unwrap();
-        Status::from(unsafe { ffi::notmuch_message_add_tag(self.handle.ptr, tag.as_ptr()) })
+        unsafe { ffi::notmuch_message_add_tag(self.handle.ptr, tag.as_ptr()) }.as_result()
     }
 
-    pub fn remove_tag(self: &Self, tag: &str) -> Status {
+    pub fn remove_tag(self: &Self, tag: &str) -> Result<()> {
         let tag = CString::new(tag).unwrap();
-        Status::from(unsafe { ffi::notmuch_message_remove_tag(self.handle.ptr, tag.as_ptr()) })
+        unsafe { ffi::notmuch_message_remove_tag(self.handle.ptr, tag.as_ptr()) }.as_result()
     }
 
-    pub fn remove_all_tags(self: &Self) -> Status {
-        Status::from(unsafe { ffi::notmuch_message_remove_all_tags(self.handle.ptr) })
+    pub fn remove_all_tags(self: &Self) -> Result<()> {
+        unsafe { ffi::notmuch_message_remove_all_tags(self.handle.ptr) }.as_result()
     }
 }
 


### PR DESCRIPTION
I noticed that ffi::Status is private, but I was trying to match if the deletion of a file from the database was successful. Realised that all the Status returns should probably be Results.

I'm not entirely sure about what the best way to go about doing that is. Here's my suggestion that only needs relatively minimal changes to the existing codebase.