### PR TITLE
destroy the msg when dropping it, closes file descriptor

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -235,6 +235,15 @@ where
     }
 }
 
+impl<'o, O> Drop for Message<'o, O>
+where
+    O: MessageOwner + 'o,
+{
+    fn drop(&mut self) {
+        unsafe { ffi::notmuch_message_destroy(self.ptr) };
+    }
+}
+
 pub trait MessageExt<'o, O>
 where
     O: MessageOwner + 'o,


### PR DESCRIPTION
Calls `notmuch_message_destroy` upon dropping the message. This frees the memory and the filedescriptor.

From the documentation:

> It can be useful to call this function in the case of a single query object with many messages in the result, (such as iterating over the entire database). Otherwise, it's fine to never call this function and there will still be no memory leaks. (The memory from the messages get reclaimed when the containing query is destroyed.)

This fixes file descriptor issues when querying a lot of messages and e.g. call header() on them.

fixes #27

Please note: I am not an experienced rust programmer, if there are any issues let me know.