### PR TITLE
Add open_with_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,20 @@ extern crate notmuch;
 ```rust
 extern crate notmuch;
 
-
 fn main() {
-
     let mut mail_path = std::env::home_dir().unwrap();
     mail_path.push(".mail");
 
-    let db = notmuch::Database::open(&mail_path, notmuch::DatabaseMode::ReadOnly).unwrap();
+    let mut config_path = std::env::home_dir().unwrap();
+    config_path.push(".config/custom-notmuch-config-path");
+
+    let db = notmuch::Database::open_with_config(
+        &mail_path,
+        notmuch::DatabaseMode::ReadOnly,
+        &config_path,
+        None,
+    )
+    .unwrap();
     let query = db.create_query("").unwrap();
     let mut threads = query.search_threads().unwrap();
 
@@ -45,7 +52,6 @@ fn main() {
         println!("thread {:?} {:?}", thread.subject(), thread.authors());
     }
 }
-
 ```
 
 ## Concurrency

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ pub type Result<T> = result::Result<T, Error>;
 pub enum Error {
     IoError(io::Error),
     NotmuchError(ffi::Status),
+    NotmuchVerboseError(ffi::Status, String),
     UnspecifiedError,
 }
 
@@ -17,6 +18,7 @@ impl fmt::Display for Error {
         match self {
             Error::IoError(e) => e.fmt(f),
             Error::NotmuchError(e) => e.fmt(f),
+            Error::NotmuchVerboseError(e, msg) => write!(f, "{} {}", e, msg),
             Error::UnspecifiedError => write!(f, "Generic notmuch error"),
         }
     }
@@ -27,6 +29,7 @@ impl error::Error for Error {
         match &self {
             Error::IoError(e) => Some(e),
             Error::NotmuchError(e) => Some(e),
+            Error::NotmuchVerboseError(e, _) => Some(e),
             Error::UnspecifiedError => None,
         }
     }


### PR DESCRIPTION
The other open functions have since been deprecated in the C API, and
the current implementation of `open` in notmuch-rs doesn't support
passing null pointers. Adding `open_with_config` and allowing it to
accept `Option` types fixes this problem in a backwards-compatible way.

I would have preferred to add a `String` to `NotmuchError` instead of
creating `NotmuchVerboseError`, but I didn't want to break
compatibility.