### PR TITLE
Add config APIs from notmuch 0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ lettre_email = "0.9.2"
 [features]
 v0_21 = []
 v0_26 = ["v0_21"]
-default = ["v0_26"]
+v0_32 = ["v0_26"]
+default = ["v0_32"]
 
 [[test]]
 name = "tests"

--- a/src/config_pairs.rs
+++ b/src/config_pairs.rs
@@ -1,0 +1,59 @@
+use std::ops::Drop;
+use std::rc::Rc;
+
+use ffi;
+use utils::ToStr;
+use Database;
+
+#[derive(Debug)]
+pub struct ConfigPairsPtr(*mut ffi::notmuch_config_pairs_t);
+
+#[derive(Clone, Debug)]
+pub struct ConfigPairs {
+    ptr: Rc<ConfigPairsPtr>,
+    _owner: Database,
+}
+
+impl Drop for ConfigPairsPtr {
+    fn drop(&mut self) {
+        unsafe { ffi::notmuch_config_pairs_destroy(self.0) };
+    }
+}
+
+impl ConfigPairs {
+    pub(crate) fn from_ptr(ptr: *mut ffi::notmuch_config_pairs_t, owner: Database) -> ConfigPairs {
+        ConfigPairs {
+            ptr: Rc::new(ConfigPairsPtr(ptr)),
+            _owner: owner,
+        }
+    }
+}
+
+impl Iterator for ConfigPairs {
+    type Item = (String, Option<String>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let valid = unsafe { ffi::notmuch_config_pairs_valid(self.ptr.0) };
+
+        if valid == 0 {
+            return None;
+        }
+
+        let (k, v) = unsafe {
+            let k = ffi::notmuch_config_pairs_key(self.ptr.0);
+            let v = ffi::notmuch_config_pairs_value(self.ptr.0);
+
+            ffi::notmuch_config_pairs_move_to_next(self.ptr.0);
+
+            (k, v)
+        };
+
+        let value = if v.is_null() {
+            None
+        } else {
+            Some(v.to_string_lossy().to_string())
+        };
+
+        Some((k.to_string_lossy().to_string(), value))
+    }
+}

--- a/src/config_values.rs
+++ b/src/config_values.rs
@@ -1,0 +1,53 @@
+use std::ops::Drop;
+use std::rc::Rc;
+
+use ffi;
+use utils::ToStr;
+use Database;
+
+#[derive(Debug)]
+pub struct ConfigValuesPtr(*mut ffi::notmuch_config_values_t);
+
+#[derive(Clone, Debug)]
+pub struct ConfigValues {
+    ptr: Rc<ConfigValuesPtr>,
+    _owner: Database,
+}
+
+impl Drop for ConfigValuesPtr {
+    fn drop(&mut self) {
+        unsafe { ffi::notmuch_config_values_destroy(self.0) };
+    }
+}
+
+impl ConfigValues {
+    pub(crate) fn from_ptr(
+        ptr: *mut ffi::notmuch_config_values_t,
+        owner: Database,
+    ) -> ConfigValues {
+        ConfigValues {
+            ptr: Rc::new(ConfigValuesPtr(ptr)),
+            _owner: owner,
+        }
+    }
+}
+
+impl Iterator for ConfigValues {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let valid = unsafe { ffi::notmuch_config_values_valid(self.ptr.0) };
+
+        if valid == 0 {
+            return None;
+        }
+
+        let value = unsafe {
+            let value = ffi::notmuch_config_values_get(self.ptr.0);
+            ffi::notmuch_config_values_move_to_next(self.ptr.0);
+            value
+        };
+
+        Some(value.to_string_lossy().to_string())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ mod ffi;
 mod utils;
 
 mod config_list;
+mod config_pairs;
+mod config_values;
 mod database;
 mod directory;
 mod error;
@@ -25,6 +27,8 @@ mod thread;
 mod threads;
 
 pub use config_list::ConfigList;
+pub use config_pairs::ConfigPairs;
+pub use config_values::ConfigValues;
 pub use database::{AtomicOperation, Database, Revision};
 pub use directory::Directory;
 pub use error::Error;
@@ -38,4 +42,4 @@ pub use tags::Tags;
 pub use thread::Thread;
 pub use threads::Threads;
 
-pub use ffi::{DatabaseMode, DecryptionPolicy, Sort, Status, Exclude, MessageFlag};
+pub use ffi::{ConfigKey, DatabaseMode, DecryptionPolicy, Exclude, MessageFlag, Sort, Status};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,6 @@
 use libc;
-use std::{ffi, str};
 use std::borrow::Cow;
-
+use std::{ffi, str};
 
 pub trait ToStr {
     fn to_str<'a>(&self) -> Result<&'a str, str::Utf8Error>;
@@ -13,15 +12,28 @@ pub trait ToStr {
 
 impl ToStr for *const libc::c_char {
     fn to_str<'a>(&self) -> Result<&'a str, str::Utf8Error> {
-        str::from_utf8(unsafe { ffi::CStr::from_ptr(*self) }.to_bytes())
+        str::from_utf8(
+            unsafe {
+                assert!(!self.is_null());
+                ffi::CStr::from_ptr(*self)
+            }
+            .to_bytes(),
+        )
     }
 
     fn to_str_unchecked<'a>(&self) -> &'a str {
-        unsafe { str::from_utf8_unchecked(ffi::CStr::from_ptr(*self).to_bytes()) }
+        unsafe {
+            assert!(!self.is_null());
+            str::from_utf8_unchecked(ffi::CStr::from_ptr(*self).to_bytes())
+        }
     }
 
     fn to_string_lossy<'a>(&self) -> Cow<'a, str> {
-        unsafe { ffi::CStr::from_ptr(*self) }.to_string_lossy()
+        unsafe {
+            assert!(!self.is_null());
+            ffi::CStr::from_ptr(*self)
+        }
+        .to_string_lossy()
     }
 }
 
@@ -31,6 +43,9 @@ pub trait ToString {
 
 impl ToString for *const libc::c_char {
     fn to_string(&self) -> String {
-        unsafe { ffi::CStr::from_ptr(*self).to_string_lossy().into_owned() }
+        unsafe {
+            assert!(!self.is_null());
+            ffi::CStr::from_ptr(*self).to_string_lossy().into_owned()
+        }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,15 +1,16 @@
 extern crate dirs;
-extern crate tempfile;
-extern crate notmuch;
 extern crate gethostname;
-extern crate maildir;
 extern crate lettre;
 extern crate lettre_email;
+extern crate maildir;
+extern crate notmuch;
+extern crate tempfile;
 
 mod fixtures;
+#[cfg(feature = "v0_32")]
+mod test_config;
 mod test_database;
-mod test_query;
-mod test_thread;
 mod test_message;
+mod test_query;
 mod test_tags;
-
+mod test_thread;

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -1,0 +1,131 @@
+use notmuch::ConfigKey;
+
+use crate::fixtures::{MailBox, NotmuchCommand};
+
+struct ConfigFixture {
+    // Return a read-write Database.
+    // The database will have 3 messages, 2 threads.
+    pub mailbox: MailBox,
+    pub database: notmuch::Database,
+}
+
+impl ConfigFixture {
+    pub fn new() -> Self {
+        let mailbox = MailBox::new();
+
+        let cmd = NotmuchCommand::new(&mailbox.path());
+        cmd.run(vec!["new"]).unwrap();
+
+        let database = notmuch::Database::open_with_config(
+            Some(&mailbox.path()),
+            notmuch::DatabaseMode::ReadWrite,
+            Some(mailbox.path().join("notmuch-config")),
+            None,
+        )
+        .unwrap();
+
+        Self { mailbox, database }
+    }
+}
+
+mod config {
+    use super::*;
+
+    #[test]
+    fn test_config() {
+        let db = ConfigFixture::new();
+
+        assert_eq!(
+            db.database.config(ConfigKey::UserName).unwrap(),
+            "Some Hacker"
+        );
+
+        assert_eq!(
+            db.database.config(ConfigKey::MailRoot).unwrap(),
+            db.mailbox.path().to_str().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_config_set() {
+        let db = ConfigFixture::new();
+
+        const USER_NAME: &str = "Hideo Kojima";
+
+        db.database
+            .config_set(ConfigKey::UserName, USER_NAME)
+            .unwrap();
+
+        assert_eq!(db.database.config(ConfigKey::UserName).unwrap(), USER_NAME);
+    }
+
+    #[test]
+    fn test_config_values() {
+        let db = ConfigFixture::new();
+
+        let tags: Vec<_> = db
+            .database
+            .config_values(ConfigKey::NewTags)
+            .unwrap()
+            .collect();
+
+        assert_eq!(tags.len(), 2);
+        assert!(tags.iter().any(|x| x == "unread"));
+        assert!(tags.iter().any(|x| x == "inbox"));
+    }
+
+    #[test]
+    fn test_config_values_string() {
+        let db = ConfigFixture::new();
+
+        let tags: Vec<_> = db
+            .database
+            .config_values_string("search.exclude_tags")
+            .unwrap()
+            .collect();
+
+        assert_eq!(tags.len(), 2);
+        assert!(tags.iter().any(|x| x == "deleted"));
+        assert!(tags.iter().any(|x| x == "spam"));
+    }
+
+    #[test]
+    fn test_config_pairs() {
+        let db = ConfigFixture::new();
+
+        let pairs: Vec<(_, _)> = db.database.config_pairs("user").unwrap().collect();
+
+        println!("{pairs:?}");
+
+        assert_eq!(pairs.len(), 3);
+        assert!(pairs
+            .iter()
+            .any(|(k, v)| k == "user.name" && v.as_deref() == Some("Some Hacker")));
+        assert!(pairs
+            .iter()
+            .any(|(k, v)| k == "user.primary_email" && v.as_deref() == Some("dst@example.com")));
+        assert!(pairs
+            .iter()
+            .any(|(k, v)| k == "user.other_email" && *v == None));
+    }
+
+    #[test]
+    fn test_config_bool() {
+        let db = ConfigFixture::new();
+
+        assert_eq!(
+            db.database.config_bool(ConfigKey::MaildirFlags).unwrap(),
+            true
+        );
+    }
+
+    #[test]
+    fn test_config_path() {
+        let db = ConfigFixture::new();
+
+        assert_eq!(
+            db.database.config_path().unwrap(),
+            db.mailbox.path().join("notmuch-config"),
+        );
+    }
+}


### PR DESCRIPTION
This kind of goes hand-in-hand with the `open_with_config` PR I submitted recently. The `notmuch_config` functions are, confusingly, very different from the `notmuch_database_get_config_list` function. These newer functions refer to the notmuch configuration file, rather than the database config (I think; they might *also* be an interface to the database config, but the API documentation wasn't too clear).

Included are the safe API wrappers and unit tests. Also, this introduces the feature `"v0_32"`, which all the new API methods are tagged with, including the `open_with_config` method. (My bad on not including it in that PR.)

I think this probably warrants a notmuch-rs version 0.8.0 if I might suggest so :)