### PR TITLE
status: don't try to unwrap null error string

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -82,7 +82,7 @@ impl notmuch_status_t {
         } else {
             Err(Error::NotmuchVerboseError(
                 Status::from(self),
-                error_message.unwrap(),
+                error_message.unwrap_or("[no info]".to_string()),
             ))
         }
     }


### PR DESCRIPTION
notmuch_database_open_with_config can fail with no additional error
message specified. Don't crash when that happens.