### PR TITLE
Fix UAF bug in Directory

### DIFF
--- a/src/directory.rs
+++ b/src/directory.rs
@@ -8,16 +8,16 @@ use Filenames;
 #[derive(Debug)]
 pub(crate) struct DirectoryPtr(*mut ffi::notmuch_directory_t);
 
+impl Drop for DirectoryPtr {
+    fn drop(&mut self) {
+        unsafe { ffi::notmuch_directory_destroy(self.0) };
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Directory {
     ptr: Rc<DirectoryPtr>,
     owner: Database,
-}
-
-impl Drop for Directory {
-    fn drop(&mut self) {
-        unsafe { ffi::notmuch_directory_destroy(self.ptr.0) };
-    }
 }
 
 impl Directory {


### PR DESCRIPTION
`Directory` holds a pointer and has a derived `Clone` implementation. If `Directory` is cloned its `ptr` field is copied to the clone, creating a new alias to the pointee. 

```rust
#[derive(Debug, Clone)]
pub struct Directory {
    ptr: Rc<DirectoryPtr>,
    owner: Database,
}
```

The `Drop` implementation for `Directory` calls `notmuch_directory_destroy` unconditionally. 

```rust
impl Drop for Directory {
    fn drop(&mut self) {
        unsafe { ffi::notmuch_directory_destroy(self.ptr.0) };
    }
}
```

Cloning an instance of `Directory` and dropping both copies causes a double-free.

## Reproducing:

### Test case:
```rust
use notmuch::Database;
use tempfile::tempdir;
use std::fs;

#[test]
fn uaf_directory_double_free() {
    let db_dir = tempdir().unwrap();
    let msg_path = db_dir.path().join("msg");
    fs::write(&msg_path, "Subject: x\nMessage-ID: <x@example.com>\n\nbody\n").unwrap();

    let db = Database::create(db_dir.path()).unwrap();
    db.index_file(&msg_path, None).unwrap();

    let foo = db.directory("").unwrap().expect("notmuch indexed the top-level dir");
    let bar = foo.clone();

    drop(foo);
    drop(bar);
}
```

You can run the above test with valgrind and see an `Invalid read` error.

```
cargo test -p notmuch --test repro --no-run
valgrind --leak-check=no ./target/debug/deps/repro-<HASH>
```

## Fix:
- Move the destructor off of `Directory` and onto `DirectoryPtr`, this way `Rc`'s own drop glue only runs it when the last clone actually goes away.